### PR TITLE
Compatibility Update for doctrine/dbal 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.0|^8.0",
-        "doctrine/dbal": ">=v2.5.0"
+        "doctrine/dbal": "^4.0"
     },
     "config": {
         "sort-packages": true,

--- a/src/DBAL/Types/BaseDateTimeMicroWithTz.php
+++ b/src/DBAL/Types/BaseDateTimeMicroWithTz.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace OwlCorp\DoctrineMicrotime\DBAL\Types;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2008Platform;
 use Doctrine\DBAL\Types\Type;
 use OwlCorp\DoctrineMicrotime\DBAL\Platform\DateTimeFormatTrait;
@@ -15,24 +15,24 @@ abstract class BaseDateTimeMicroWithTz extends Type
 {
     use DateTimeFormatTrait;
 
-    const NAME = null;
+    public const string NAME = 'datetimetz_micro';
 
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        if ($platform instanceof PostgreSqlPlatform || $platform instanceof OraclePlatform) {
+        if ($platform instanceof PostgreSQLPlatform || $platform instanceof OraclePlatform) {
             return 'TIMESTAMP(6) WITH TIME ZONE';
         }
 
         if ($platform instanceof SQLServer2008Platform) {
-            return $platform->getDateTimeTypeDeclarationSQL($fieldDeclaration);
+            return $platform->getDateTimeTypeDeclarationSQL($column);
         }
 
-        throw new DBALException(
+        throw new NotSupported(
             \sprintf(
                 '%s ("%s") type is not supported on "%s" platform',
                 $this->getName(),

--- a/src/DBAL/Types/BaseDateTimeMicroWithoutTz.php
+++ b/src/DBAL/Types/BaseDateTimeMicroWithoutTz.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace OwlCorp\DoctrineMicrotime\DBAL\Types;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\Exception\NotSupported;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\Type;
 use OwlCorp\DoctrineMicrotime\DBAL\Platform\DateTimeFormatTrait;
@@ -17,32 +17,32 @@ abstract class BaseDateTimeMicroWithoutTz extends Type
 {
     use DateTimeFormatTrait;
 
-    const NAME = null;
+    public const string NAME = 'datetime_micro';
 
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        if ($platform instanceof PostgreSqlPlatform) {
+        if ($platform instanceof PostgreSQLPlatform) {
             return 'TIMESTAMP(6) WITHOUT TIME ZONE';
         }
 
-        if ($platform instanceof MySqlPlatform) {
-            return $platform->getDateTimeTypeDeclarationSQL($fieldDeclaration) . '(6)';
+        if ($platform instanceof MySQLPlatform) {
+            return $platform->getDateTimeTypeDeclarationSQL($column) . '(6)';
         }
 
         if ($platform instanceof OraclePlatform) {
             return 'TIMESTAMP(6)';
         }
 
-        if ($platform instanceof SqlitePlatform || $platform instanceof SQLServerPlatform) {
-            return $platform->getDateTimeTypeDeclarationSQL($fieldDeclaration);
+        if ($platform instanceof SQLitePlatform || $platform instanceof SQLServerPlatform) {
+            return $platform->getDateTimeTypeDeclarationSQL($column);
         }
 
-        throw new DBALException(
+        throw new NotSupported(
             \sprintf(
                 '%s ("%s") type is not supported on "%s" platform',
                 $this->getName(),

--- a/src/DBAL/Types/BaseTimeMicro.php
+++ b/src/DBAL/Types/BaseTimeMicro.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace OwlCorp\DoctrineMicrotime\DBAL\Types;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\Exception\NotSupported;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\Type;
 use OwlCorp\DoctrineMicrotime\DBAL\Platform\DateTimeFormatTrait;
@@ -17,32 +17,32 @@ abstract class BaseTimeMicro extends Type
 {
     use DateTimeFormatTrait;
 
-    const NAME = null;
+    public const string NAME = 'time_micro';
 
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        if ($platform instanceof PostgreSqlPlatform) {
+        if ($platform instanceof PostgreSQLPlatform) {
             return 'TIME(6) WITHOUT TIME ZONE';
         }
 
-        if ($platform instanceof MySqlPlatform) {
-            return $platform->getDateTimeTypeDeclarationSQL($fieldDeclaration) . '(6)';
+        if ($platform instanceof MySQLPlatform) {
+            return $platform->getDateTimeTypeDeclarationSQL($column) . '(6)';
         }
 
         if ($platform instanceof OraclePlatform) {
             return 'TIMESTAMP(6)'; //there's no way to save just time
         }
 
-        if ($platform instanceof SqlitePlatform || $platform instanceof SQLServerPlatform) {
-            return $platform->getDateTimeTypeDeclarationSQL($fieldDeclaration);
+        if ($platform instanceof SQLitePlatform || $platform instanceof SQLServerPlatform) {
+            return $platform->getDateTimeTypeDeclarationSQL($column);
         }
 
-        throw new DBALException(
+        throw new NotSupported(
             \sprintf(
                 '%s ("%s") type is not supported on "%s" platform',
                 $this->getName(),

--- a/src/DBAL/Types/DateTimeImmutableMicroType.php
+++ b/src/DBAL/Types/DateTimeImmutableMicroType.php
@@ -4,45 +4,45 @@ declare(strict_types=1);
 namespace OwlCorp\DoctrineMicrotime\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 
 final class DateTimeImmutableMicroType extends BaseDateTimeMicroWithoutTz
 {
-    const NAME = 'datetime_immutable_micro';
+    public const string NAME = 'datetime_immutable_micro';
 
-    public function convertToDatabaseValue($phpVal, AbstractPlatform $platform)
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($phpVal === null) {
-            return $phpVal;
+        if ($value === null) {
+            return $value;
         }
 
-        if ($phpVal instanceof \DateTimeImmutable) {
-            return $phpVal->format($this->getDateTimeFormatString($platform));
+        if ($value instanceof \DateTimeImmutable) {
+            return $value->format($this->getDateTimeFormatString($platform));
         }
 
-        throw ConversionException::conversionFailedFormat(
-            $phpVal,
+        throw InvalidFormat::new(
+            $value,
             $this->getName(),
             $this->getDateTimeFormatString($platform)
         );
     }
 
-    public function convertToPHPValue($dbVal, AbstractPlatform $platform)
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($dbVal === null || $dbVal instanceof \DateTimeImmutable) {
-            return $dbVal;
+        if ($value === null || $value instanceof \DateTimeImmutable) {
+            return $value;
         }
 
-        $phpVal = \DateTimeImmutable::createFromFormat($this->getDateTimeFormatString($platform), $dbVal);
+        $phpVal = \DateTimeImmutable::createFromFormat($this->getDateTimeFormatString($platform), $value);
         if ($phpVal !== false) {
             return $phpVal;
         }
 
         try {
-            return new \DateTimeImmutable($dbVal); //it is usually able to guess
+            return new \DateTimeImmutable($value); //it is usually able to guess
         } catch (\Throwable $t) {
-            throw ConversionException::conversionFailedFormat(
-                $dbVal,
+            throw InvalidFormat::new(
+                $value,
                 $this->getName(),
                 $platform->getDateTimeFormatString()
             );

--- a/src/DBAL/Types/DateTimeMicroType.php
+++ b/src/DBAL/Types/DateTimeMicroType.php
@@ -4,45 +4,45 @@ declare(strict_types=1);
 namespace OwlCorp\DoctrineMicrotime\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 
 final class DateTimeMicroType extends BaseDateTimeMicroWithoutTz
 {
-    const NAME = 'datetime_micro';
+    public const string NAME = 'datetime_micro';
 
-    public function convertToDatabaseValue($phpVal, AbstractPlatform $platform)
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($phpVal === null) {
-            return $phpVal;
+        if ($value === null) {
+            return $value;
         }
 
-        if ($phpVal instanceof \DateTimeInterface) {
-            return $phpVal->format($this->getDateTimeFormatString($platform));
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format($this->getDateTimeFormatString($platform));
         }
 
-        throw ConversionException::conversionFailedFormat(
-            $phpVal,
+        throw InvalidFormat::new(
+            $value,
             $this->getName(),
             $this->getDateTimeFormatString($platform)
         );
     }
 
-    public function convertToPHPValue($dbVal, AbstractPlatform $platform)
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($dbVal === null || $dbVal instanceof \DateTimeInterface) {
-            return $dbVal;
+        if ($value === null || $value instanceof \DateTimeInterface) {
+            return $value;
         }
 
-        $phpVal = \DateTime::createFromFormat($this->getDateTimeFormatString($platform), $dbVal);
+        $phpVal = \DateTime::createFromFormat($this->getDateTimeFormatString($platform), $value);
         if ($phpVal !== false) {
             return $phpVal;
         }
 
         try {
-            return new \DateTime($dbVal); //it is usually able to guess
+            return new \DateTime($value); //it is usually able to guess
         } catch (\Throwable $t) {
-            throw ConversionException::conversionFailedFormat(
-                $dbVal,
+            throw InvalidFormat::new(
+                $value,
                 $this->getName(),
                 $platform->getDateTimeFormatString()
             );

--- a/src/DBAL/Types/DateTimeTzImmutableMicroType.php
+++ b/src/DBAL/Types/DateTimeTzImmutableMicroType.php
@@ -4,45 +4,45 @@ declare(strict_types=1);
 namespace OwlCorp\DoctrineMicrotime\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 
 final class DateTimeTzImmutableMicroType extends BaseDateTimeMicroWithTz
 {
-    const NAME = 'datetimetz_immutable_micro';
+    public const string NAME = 'datetimetz_immutable_micro';
 
-    public function convertToDatabaseValue($phpVal, AbstractPlatform $platform)
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($phpVal === null) {
-            return $phpVal;
+        if ($value === null) {
+            return $value;
         }
 
-        if ($phpVal instanceof \DateTimeImmutable) {
-            return $phpVal->format($this->getDateTimeTzFormatString($platform));
+        if ($value instanceof \DateTimeImmutable) {
+            return $value->format($this->getDateTimeTzFormatString($platform));
         }
 
-        throw ConversionException::conversionFailedFormat(
-            $phpVal,
+        throw InvalidFormat::new(
+            $value,
             $this->getName(),
             $this->getDateTimeTzFormatString($platform)
         );
     }
 
-    public function convertToPHPValue($dbVal, AbstractPlatform $platform)
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($dbVal === null || $dbVal instanceof \DateTimeImmutable) {
-            return $dbVal;
+        if ($value === null || $value instanceof \DateTimeImmutable) {
+            return $value;
         }
 
-        $phpVal = \DateTimeImmutable::createFromFormat($this->getDateTimeTzFormatString($platform), $dbVal);
+        $phpVal = \DateTimeImmutable::createFromFormat($this->getDateTimeTzFormatString($platform), $value);
         if ($phpVal !== false) {
             return $phpVal;
         }
 
         try {
-            return new \DateTimeImmutable($dbVal); //it is usually able to guess
+            return new \DateTimeImmutable($value); //it is usually able to guess
         } catch (\Throwable $t) {
-            throw ConversionException::conversionFailedFormat(
-                $dbVal,
+            throw InvalidFormat::new(
+                $value,
                 $this->getName(),
                 $platform->getDateTimeTzFormatString()
             );

--- a/src/DBAL/Types/DateTimeTzMicroType.php
+++ b/src/DBAL/Types/DateTimeTzMicroType.php
@@ -4,45 +4,45 @@ declare(strict_types=1);
 namespace OwlCorp\DoctrineMicrotime\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 
 final class DateTimeTzMicroType extends BaseDateTimeMicroWithTz
 {
-    const NAME = 'datetimetz_micro';
+    public const string NAME = 'datetimetz_micro';
 
-    public function convertToDatabaseValue($phpVal, AbstractPlatform $platform)
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($phpVal === null) {
-            return $phpVal;
+        if ($value === null) {
+            return $value;
         }
 
-        if ($phpVal instanceof \DateTimeInterface) {
-            return $phpVal->format($this->getDateTimeTzFormatString($platform));
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format($this->getDateTimeTzFormatString($platform));
         }
 
-        throw ConversionException::conversionFailedFormat(
-            $phpVal,
+        throw InvalidFormat::new(
+            $value,
             $this->getName(),
             $this->getDateTimeTzFormatString($platform)
         );
     }
 
-    public function convertToPHPValue($dbVal, AbstractPlatform $platform)
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($dbVal === null || $dbVal instanceof \DateTimeInterface) {
-            return $dbVal;
+        if ($value === null || $value instanceof \DateTimeInterface) {
+            return $value;
         }
 
-        $phpVal = \DateTime::createFromFormat($this->getDateTimeTzFormatString($platform), $dbVal);
+        $phpVal = \DateTime::createFromFormat($this->getDateTimeTzFormatString($platform), $value);
         if ($phpVal !== false) {
             return $phpVal;
         }
 
         try {
-            return new \DateTime($dbVal); //it is usually able to guess
+            return new \DateTime($value); //it is usually able to guess
         } catch (\Throwable $t) {
-            throw ConversionException::conversionFailedFormat(
-                $dbVal,
+            throw InvalidFormat::new(
+                $value,
                 $this->getName(),
                 $platform->getDateTimeTzFormatString()
             );

--- a/src/DBAL/Types/TimeImmutableMicroType.php
+++ b/src/DBAL/Types/TimeImmutableMicroType.php
@@ -4,49 +4,49 @@ declare(strict_types=1);
 namespace OwlCorp\DoctrineMicrotime\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use OwlCorp\DoctrineMicrotime\DBAL\Platform\DateTimeFormatTrait;
 
 final class TimeImmutableMicroType extends BaseTimeMicro
 {
     use DateTimeFormatTrait;
 
-    const NAME = 'time_immutable_micro';
+    public const string NAME = 'time_immutable_micro';
 
-    public function convertToDatabaseValue($phpVal, AbstractPlatform $platform)
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($phpVal === null) {
-            return $phpVal;
+        if ($value === null) {
+            return $value;
         }
 
-        if ($phpVal instanceof \DateTimeImmutable) {
-            return $phpVal->format($this->getTimeFormatString($platform));
+        if ($value instanceof \DateTimeImmutable) {
+            return $value->format($this->getTimeFormatString($platform));
         }
 
-        throw ConversionException::conversionFailedFormat(
-            $phpVal,
+        throw InvalidFormat::new(
+            $value,
             $this->getName(),
             $this->getTimeFormatString($platform)
         );
     }
 
-    public function convertToPHPValue($dbVal, AbstractPlatform $platform)
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($dbVal === null || $dbVal instanceof \DateTimeImmutable) {
-            return $dbVal;
+        if ($value === null || $value instanceof \DateTimeImmutable) {
+            return $value;
         }
 
         //The "!" forces Y-m-d to be set to beginning of unix epoch
-        $phpVal = \DateTimeImmutable::createFromFormat('!' . $this->getTimeFormatString($platform), $dbVal);
+        $phpVal = \DateTimeImmutable::createFromFormat('!' . $this->getTimeFormatString($platform), $value);
         if ($phpVal !== false) {
             return $phpVal;
         }
 
         try {
-            return new \DateTime($dbVal); //it is usually able to guess
+            return new \DateTime($value); //it is usually able to guess
         } catch (\Throwable $t) {
-            throw ConversionException::conversionFailedFormat(
-                $dbVal,
+            throw InvalidFormat::new(
+                $value,
                 $this->getName(),
                 $platform->getDateTimeFormatString()
             );

--- a/src/DBAL/Types/TimeMicroType.php
+++ b/src/DBAL/Types/TimeMicroType.php
@@ -4,49 +4,49 @@ declare(strict_types=1);
 namespace OwlCorp\DoctrineMicrotime\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use OwlCorp\DoctrineMicrotime\DBAL\Platform\DateTimeFormatTrait;
 
 final class TimeMicroType extends BaseTimeMicro
 {
     use DateTimeFormatTrait;
 
-    const NAME = 'time_micro';
+    public const string NAME = 'time_micro';
 
-    public function convertToDatabaseValue($phpVal, AbstractPlatform $platform)
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($phpVal === null) {
-            return $phpVal;
+        if ($value === null) {
+            return $value;
         }
 
-        if ($phpVal instanceof \DateTimeInterface) {
-            return $phpVal->format($this->getTimeFormatString($platform));
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format($this->getTimeFormatString($platform));
         }
 
-        throw ConversionException::conversionFailedFormat(
-            $phpVal,
+        throw InvalidFormat::new(
+            $value,
             $this->getName(),
             $this->getTimeFormatString($platform)
         );
     }
 
-    public function convertToPHPValue($dbVal, AbstractPlatform $platform)
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if ($dbVal === null || $dbVal instanceof \DateTimeInterface) {
-            return $dbVal;
+        if ($value === null || $value instanceof \DateTimeInterface) {
+            return $value;
         }
 
         //The "!" forces Y-m-d to be set to beginning of unix epoch
-        $phpVal = \DateTime::createFromFormat('!' . $this->getTimeFormatString($platform), $dbVal);
+        $phpVal = \DateTime::createFromFormat('!' . $this->getTimeFormatString($platform), $value);
         if ($phpVal !== false) {
             return $phpVal;
         }
 
         try {
-            return new \DateTime($dbVal); //it is usually able to guess
+            return new \DateTime($value); //it is usually able to guess
         } catch (\Throwable $t) {
-            throw ConversionException::conversionFailedFormat(
-                $dbVal,
+            throw InvalidFormat::new(
+                $value,
                 $this->getName(),
                 $platform->getDateTimeFormatString()
             );


### PR DESCRIPTION
Thank you for providing this one!

As recent doctrine versions changed some method signatures, I went over this package and adjusted it accordingly.

Handled changes ([Doctrine Changelog](https://github.com/doctrine/dbal/blob/4.2.x/UPGRADE.md)):
- [BC BREAK: Doctrine\DBAL\DBALException class renamed](https://github.com/doctrine/dbal/blob/4.2.x/UPGRADE.md#bc-break-doctrinedbaldbalexception-class-renamed)
- [BC BREAK: Exception classes have been converted to interfaces](https://github.com/doctrine/dbal/blob/4.2.x/UPGRADE.md#bc-break-exception-classes-have-been-converted-to-interfaces)
- [BC BREAK: Removed DBALException factory methods](https://github.com/doctrine/dbal/blob/4.2.x/UPGRADE.md#bc-break-removed-dbalexception-factory-methods)
- Added method return types to comply with parent signatures
- Renamed method arguments according to their parents
- Fixed spelling of Platform-classes (different casing)

A thing I haven't touched: The class `Doctrine\DBAL\Platforms\SQLServer2008Platform` was removed with doctrine/dbal version 3.0 ([link to changelog](https://github.com/doctrine/dbal/blob/4.2.x/UPGRADE.md#bc-break-removed-support-for-sql-server-2008-and-older)). I'm not familiar enough with SQLServer to know if the code branches should be removed or the conditions can be opened to apply on SQLServer in general.

As this MR is full of breaking changes it should lead to a major release.